### PR TITLE
fix: Fixing potential region mismatch

### DIFF
--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -9,6 +9,8 @@
           - uses: actions/checkout@v4
             with:
               ref: ${{ github.event.pull_request.head.ref }}
+              repository: ${{github.event.pull_request.head.repo.full_name}}
+
 
           - name: Render terraform docs inside the README.md and push changes back to PR branch
             uses: terraform-docs/gh-actions@v1.0.0

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -6,7 +6,7 @@
       docs:
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@v4
             with:
               ref: ${{ github.event.pull_request.head.ref }}
 

--- a/.github/workflows/terraform-docs.yaml
+++ b/.github/workflows/terraform-docs.yaml
@@ -16,7 +16,7 @@
             uses: terraform-docs/gh-actions@v1.0.0
             with:
               working-dir: .
-              config-file: .terraform-docs.yml
+              config-file: .terraform-docs.yaml
               output-file: README.md
               output-method: inject
               git-push: "true"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ No modules.
 | [google-beta_google_cloudbuildv2_repository.repositories](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_cloudbuildv2_repository) | resource |
 | [google_secret_manager_secret.github_auth_token](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
 | [google_secret_manager_secret_iam_member.clouduild_github_auth_token](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 | [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 | [google_secret_manager_secret_version.github_auth_token](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret_version) | data source |
 
@@ -39,7 +40,7 @@ No modules.
 | <a name="input_github_connection_name"></a> [github\_connection\_name](#input\_github\_connection\_name) | Name of the Cloud Build v2 Connection to GitHub | `string` | `"github"` | no |
 | <a name="input_oauth_token_secret"></a> [oauth\_token\_secret](#input\_oauth\_token\_secret) | Name of the GitHub OAuth Token Secret | `string` | `"github-token"` | no |
 | <a name="input_oauth_token_secret_version"></a> [oauth\_token\_secret\_version](#input\_oauth\_token\_secret\_version) | Secret Version ID of the GitHub OAuth Token | `string` | `"latest"` | no |
-| <a name="input_region"></a> [region](#input\_region) | Region of the Cloud Build v2 Connection to GitHub | `string` | `"us-central1"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region of the Cloud Build v2 Connection to GitHub | `string` | `""` | no |
 | <a name="input_repositories"></a> [repositories](#input\_repositories) | List of GitHub repositories to create Cloud Build v2 Repositories for | `list(string)` | `[]` | no |
 | <a name="input_secret_project"></a> [secret\_project](#input\_secret\_project) | Google Project ID in which the GitHub OAuth Token Secret is stored | `string` | `null` | no |
 

--- a/connection.tf
+++ b/connection.tf
@@ -2,7 +2,7 @@
 resource "google_cloudbuildv2_connection" "github" {
   provider = google-beta
   project  = var.project
-  location = var.region
+  location = local.region
   name     = var.github_connection_name
 
   github_config {

--- a/locals.tf
+++ b/locals.tf
@@ -5,5 +5,7 @@ locals {
 
   # Project ID in which the GitHub OAuth Token Secret is stored
   secret_project = coalesce(var.secret_project, var.project)
+  # Use the provider region unless passed in as a variable
+  region = coalesce(var.region, data.google_client_config.current.region)
 
 }

--- a/main.tf
+++ b/main.tf
@@ -10,3 +10,5 @@ terraform {
     }
   }
 }
+
+data "google_client_config" "current" {}

--- a/repositories.tf
+++ b/repositories.tf
@@ -4,7 +4,7 @@ resource "google_cloudbuildv2_repository" "repositories" {
   provider = google-beta
   name     = each.key
   project  = var.project
-  location = var.region
+  location = local.region
 
   parent_connection = google_cloudbuildv2_connection.github.name
   remote_uri        = "https://github.com/${var.github_login}/${each.key}.git"

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "project" {
 variable "region" {
   description = "Region of the Cloud Build v2 Connection to GitHub"
   type        = string
-  default     = "us-central1"
+  default     = ""
 }
 
 variable "repositories" {


### PR DESCRIPTION
If you do not pass the optional region parameter currently, the module uses the region of the Google Provider for some resource, and the default value of the var for others, which can result in this error

```
google_cloudbuild_trigger.build-default-branch["item"]: Creating...
╷
│ Error: Error creating Trigger: googleapi: Error 400: location of the repository: us-central1 does not match the current region: us-east4
```

I've updated the code to use the provider region, unless the region var has been specifically passed.